### PR TITLE
Move client conn handler to separate file

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,20 +1,10 @@
 'use strict'
 
-const ws = require('websocket-stream')
 const {createServer} = require('net')
-const pipe = require('pump')
-const debug = require('debug')('tcp-over-websockets:client')
+const {tunnelTo} = require('./tunnel')
 
 const startClient = (tunnel, target, port, cb) => {
-	const tcpServer = createServer((local) => {
-		const remote = ws(tunnel + (tunnel.slice(-1) === '/' ? '' : '/') + target)
-
-		const onError = (err) => {
-			if (err) debug(err)
-		}
-		pipe(remote, local, onError)
-		pipe(local, remote, onError)
-	})
+	const tcpServer = createServer(tunnelTo(tunnel, target))
 
 	tcpServer.listen(port, cb)
 	return tcpServer

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"files": [
 		"client.js",
 		"server.js",
+		"tunnel.js",
 		"cli"
 	],
 	"keywords": [

--- a/tunnel.js
+++ b/tunnel.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const ws = require('websocket-stream')
+const pipe = require('pump')
+const debug = require('debug')('tcp-over-websockets:client')
+
+const tunnelTo = (tunnel, target) => (local) => {
+	const remote = ws(tunnel + (tunnel.slice(-1) === '/' ? '' : '/') + target)
+
+	const onError = (err) => {
+		if (err) debug(err)
+	}
+	pipe(remote, local, onError)
+	pipe(local, remote, onError)
+}
+
+module.exports = {tunnelTo}


### PR DESCRIPTION
Users of this package may wish to build their own clients that connect
to a tcp-over-websockets server. This change makes the TCP tunnelling
handler available to package users, while still keeping the
module.exports conventions used here.

- Create `tunnel`, a new module
- Move handler that tunnels an incoming TCP connection from `client`
  to `tunnel`, naming the function `tunnelTo`
- Add `tunnel.js`to manifest of files to be exported by package.json