### PR TITLE
feat(tunnel): return remote web socket

### DIFF
--- a/tunnel.js
+++ b/tunnel.js
@@ -12,6 +12,7 @@ const tunnelTo = (tunnel, target) => (local) => {
 	}
 	pipe(remote, local, onError)
 	pipe(local, remote, onError)
+	return remote
 }
 
 module.exports = {tunnelTo}


### PR DESCRIPTION
Callers of `tunnelTo()` may want to have a reference to the websocket for further manipulation, eg, to add a transform  between local and remote mid-flight. Return the remote socket to facilitate this.